### PR TITLE
add support for fingerprint:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM appleboy/drone-ssh:1.5.7-linux-amd64
+FROM appleboy/drone-ssh:1.5.8-linux-amd64
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See [action.yml](./action.yml) for more detailed information.
 * command_timeout - timeout for ssh command, default is `10m`
 * key - content of ssh private key. ex raw content of ~/.ssh/id_rsa
 * key_path - path of ssh private key
+* fingerprint - fingerprint SHA256 of the host public key, default is to skip verification
 * script - execute commands
 * script_stop - stop script after first failure
 * envs - pass environment variable to shell script
@@ -72,6 +73,7 @@ SSH Proxy Setting:
 * proxy_timeout - timeout for ssh to proxy host, default is `30s`
 * proxy_key - content of ssh proxy private key.
 * proxy_key_path - path of ssh proxy private key
+* proxy_fingerprint - fingerprint SHA256 of the proxy host public key, default is to skip verification
 
 ### Example
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,8 @@ inputs:
     description: 'content of ssh private key. ex raw content of ~/.ssh/id_rsa'
   key_path:
     description: 'path of ssh private key'
+  fingerprint:
+    description: 'sha256 fingerprint of the host public key'
   proxy_host:
     description: 'ssh proxy host'
   proxy_port:
@@ -44,6 +46,8 @@ inputs:
     description: 'content of ssh proxy private key. ex raw content of ~/.ssh/id_rsa'
   proxy_key_path:
     description: 'path of ssh proxy private key'
+  proxy_fingerprint:
+    description: 'sha256 fingerprint of the proxy host public key'
   script:
     description: 'execute commands'
   script_stop:


### PR DESCRIPTION
This won't work until https://github.com/appleboy/drone-ssh gets the updated easyssh-proxy (with https://github.com/appleboy/easyssh-proxy/pull/57).

I didn't create the appleboy/drone-ssh pull request since it _seemed_ like there was existing automation (?). If I misunderstood, I can create the necessary pull request in appleboy/drone-ssh.