### PR TITLE
(info) Pass env variable as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Pass environment variable to shell script
         echo "sha: $SHA"
 ```
 
+_Inside `env` object, you need to pass every environment variable as a string, passing `Integer` data type or any other may output unexpected results._
+
 Stop script after first failure. ex: missing `abc` folder
 
 ```diff


### PR DESCRIPTION
The PR adds information about adding the environment variables at `String`.

> I was facing the exact same issue, where I was trying to pass an `PORT` env variable as Integer, which output some weird issues. 