### PR TITLE
docu(restructure): update readme structure and add ed25519 ssh key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,9 @@ It is not uncommon for files to leak from backups or decommissioned hardware, an
         whoami
         ls -al
 ```
+
+## Contributing
+We would love for you to contribute to `appleboy/ssh-action`, pull requests are welcome!
+
+## License
+The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,42 @@
 
 **Important**: Only support **Linux** [docker](https://www.docker.com/) container.
 
+## Input variables
+
+See [action.yml](./action.yml) for more detailed information.
+
+* `host` - ssh host
+* `port` - ssh port, default is `22`
+* `username` - ssh username
+* `password` - ssh password
+* `passphrase` - the passphrase is usually to encrypt the private key
+* `sync` - synchronous execution if multiple hosts, default is false
+* `timeout` - timeout for ssh to remote host, default is `30s`
+* `command_timeout` - timeout for ssh command, default is `10m`
+* `key` - content of ssh private key. ex raw content of ~/.ssh/id_rsa
+* `key_path` - path of ssh private key
+* `fingerprint` - fingerprint SHA256 of the host public key, default is to skip verification
+* `script` - execute commands
+* `script_stop` - stop script after first failure
+* `envs` - pass environment variable to shell script
+* `debug` - enable debug mode
+* `use_insecure_cipher` - include more ciphers with use_insecure_cipher (see [#56](https://github.com/appleboy/ssh-action/issues/56))
+* `cipher` - the allowed cipher algorithms. If unspecified then a sensible
+
+SSH Proxy Setting:
+
+* `proxy_host` - proxy host
+* `proxy_port` - proxy port, default is `22`
+* `proxy_username` - proxy username
+* `proxy_password` - proxy password
+* `proxy_passphrase` - the passphrase is usually to encrypt the private key
+* `proxy_timeout` - timeout for ssh to proxy host, default is `30s`
+* `proxy_key` - content of ssh proxy private key.
+* `proxy_key_path` - path of ssh proxy private key
+* `proxy_fingerprint` - fingerprint SHA256 of the proxy host public key, default is to skip verification
+* `proxy_use_insecure_cipher` - include more ciphers with use_insecure_cipher (see [#56](https://github.com/appleboy/ssh-action/issues/56))
+* `proxy_cipher` - the allowed cipher algorithms. If unspecified then a sensible
+
 ## Usage
 
 Executing remote ssh commands.
@@ -43,42 +79,6 @@ out: ***
 ==============================================
 ```
 
-## Input variables
-
-See [action.yml](./action.yml) for more detailed information.
-
-* host - ssh host
-* port - ssh port, default is `22`
-* username - ssh username
-* password - ssh password
-* passphrase - the passphrase is usually to encrypt the private key
-* sync - synchronous execution if multiple hosts, default is false
-* timeout - timeout for ssh to remote host, default is `30s`
-* command_timeout - timeout for ssh command, default is `10m`
-* key - content of ssh private key. ex raw content of ~/.ssh/id_rsa
-* key_path - path of ssh private key
-* fingerprint - fingerprint SHA256 of the host public key, default is to skip verification
-* script - execute commands
-* script_stop - stop script after first failure
-* envs - pass environment variable to shell script
-* debug - enable debug mode
-* use_insecure_cipher - include more ciphers with use_insecure_cipher (see [#56](https://github.com/appleboy/ssh-action/issues/56))
-* cipher - the allowed cipher algorithms. If unspecified then a sensible
-
-SSH Proxy Setting:
-
-* proxy_host - proxy host
-* proxy_port - proxy port, default is `22`
-* proxy_username - proxy username
-* proxy_password - proxy password
-* proxy_passphrase - the passphrase is usually to encrypt the private key
-* proxy_timeout - timeout for ssh to proxy host, default is `30s`
-* proxy_key - content of ssh proxy private key.
-* proxy_key_path - path of ssh proxy private key
-* proxy_fingerprint - fingerprint SHA256 of the proxy host public key, default is to skip verification
-* proxy_use_insecure_cipher - include more ciphers with use_insecure_cipher (see [#56](https://github.com/appleboy/ssh-action/issues/56))
-* proxy_cipher - the allowed cipher algorithms. If unspecified then a sensible
-
 ### Setting up SSH Key
 
 Make sure to follow the below steps while creating SSH Keys and using them.
@@ -105,7 +105,7 @@ See the detail information about [SSH login without password](http://www.linuxpr
 
 ### Example
 
-Executing remote ssh commands using password.
+#### Executing remote ssh commands using password
 
 ```yaml
 - name: executing remote ssh commands using password
@@ -118,7 +118,7 @@ Executing remote ssh commands using password.
     script: whoami
 ```
 
-Using private key
+#### Using private key
 
 ```yaml
 - name: executing remote ssh commands using ssh key
@@ -131,7 +131,7 @@ Using private key
     script: whoami
 ```
 
-Multiple Commands
+#### Multiple Commands
 
 ```yaml
 - name: multiple command
@@ -148,7 +148,7 @@ Multiple Commands
 
 ![result](./images/output-result.png)
 
-Multiple Hosts
+#### Multiple Hosts
 
 ```diff
   - name: multiple host
@@ -164,7 +164,7 @@ Multiple Hosts
         ls -al
 ```
 
-Multiple hosts with different port
+#### Multiple hosts with different port
 
 ```diff
   - name: multiple host
@@ -179,7 +179,7 @@ Multiple hosts with different port
         ls -al
 ```
 
-Synchronous execution on multiple hosts
+#### Synchronous execution on multiple hosts
 
 ```diff
   - name: multiple host
@@ -195,7 +195,7 @@ Synchronous execution on multiple hosts
         ls -al
 ```
 
-Pass environment variable to shell script
+#### Pass environment variable to shell script
 
 ```diff
   - name: pass environment
@@ -218,7 +218,9 @@ Pass environment variable to shell script
 
 _Inside `env` object, you need to pass every environment variable as a string, passing `Integer` data type or any other may output unexpected results._
 
-Stop script after first failure. ex: missing `abc` folder
+#### Stop script after first failure
+
+> ex: missing `abc` folder
 
 ```diff
   - name: stop script if command error
@@ -247,7 +249,7 @@ err: mkdir: cannot create directory ‘abc/def’: No such file or directory
 ##[error]Docker run failed with exit code 1
 ```
 
-How to connect remote server using `ProxyCommand`?
+#### How to connect remote server using `ProxyCommand`?
 
 ```bash
 +--------+       +----------+      +-----------+
@@ -271,7 +273,7 @@ Host FooServer
   ProxyCommand ssh -q -W %h:%p Jumphost
 ```
 
-How to convert to YAML format of GitHubActions.
+#### How to convert to YAML format of GitHubActions
 
 ```diff
   - name: ssh proxy command
@@ -290,7 +292,11 @@ How to convert to YAML format of GitHubActions.
         ls -al
 ```
 
-Protecting a Private Key. The purpose of the passphrase is usually to encrypt the private key. This makes the key file by itself useless to an attacker. It is not uncommon for files to leak from backups or decommissioned hardware, and hackers commonly exfiltrate files from compromised systems.
+#### Protecting a Private Key
+
+The purpose of the passphrase is usually to encrypt the private key.
+This makes the key file by itself useless to an attacker. 
+It is not uncommon for files to leak from backups or decommissioned hardware, and hackers commonly exfiltrate files from compromised systems.
 
 ```diff
   - name: ssh key passphrase

--- a/README.md
+++ b/README.md
@@ -79,27 +79,81 @@ out: ***
 ==============================================
 ```
 
-### Setting up SSH Key
+### Setting up a SSH Key
 
 Make sure to follow the below steps while creating SSH Keys and using them.
 The best practice is create the SSH Keys on local machine not remote machine.
 Login with username specified in Github Secrets. Generate a RSA Key-Pair:
 
- ```bash
- ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
- ```
+<details>
+<summary>rsa</summary>
+<p>
+
+```bash
+ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
+```
+
+</p>
+</details>
+
+<details>
+<summary>ed25519</summary>
+<p>
+
+```bash
+ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
+```
+
+</p>
+</details>
 
 Add newly generated key into Authorized keys. Read more about authorized keys [here](https://www.ssh.com/ssh/authorized_keys/).
+
+<details>
+<summary>rsa</summary>
+<p>
 
 ```bash
 cat .ssh/id_rsa.pub | ssh b@B 'cat >> .ssh/authorized_keys'
 ```
 
+</p>
+</details>
+
+<details>
+<summary>ed25519</summary>
+<p>
+
+```bash
+cat .ssh/id_ed25519.pub | ssh b@B 'cat >> .ssh/authorized_keys'
+```
+
+</p>
+</details>
+
 Copy Private Key content and paste in Github Secrets.
+
+<details>
+<summary>rsa</summary>
+<p>
 
 ```bash
 clip < ~/.ssh/id_rsa
 ```
+
+</p>
+</details>
+
+<details>
+<summary>ed25519</summary>
+<p>
+
+```bash
+clip < ~/.ssh/id_ed25519
+```
+
+</p>
+</details>
 
 See the detail information about [SSH login without password](http://www.linuxproblem.org/art_9.html)
 


### PR DESCRIPTION
### Description

This PR aims to slightly improve the readme examples by slightly reordering and making them linkable (via markdown headlines).
Also adds the `ed25519` key format instructions to the ssh-keys section.

Note: alternatively I could extract the examples in the likes of [actions/cache](https://github.com/actions/cache#implementation-examples), but then I think that would be a bit overblown for this. (However, if you want me to I can do that too)

### Changes

* make examples linkable and searchable by new github readme TOC
* add `ed25519` ssh key instructions
* add Contributing and Licence info to readme

### Issues

* #112 (see comment)