### PR TITLE
Document setup of SSH host fingerprint validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,32 @@ It is not uncommon for files to leak from backups or decommissioned hardware, an
         ls -al
 ```
 
+#### Using host fingerprint verification
+
+Setting up SSH host fingerprint verification can help to prevent Person-in-the-Middle attacks. Before setting this up, run the command below to get your SSH host fingerprint. Remember to replace `ed25519` with your appropriate key type (`rsa`, `dsa`, etc.) that your server is using and `example.com` with your host.
+
+In modern OpenSSH releases, the _default_ key types to be fetched are `rsa` (since version 5.1), `ecdsa` (since version 6.0), and `ed25519` (since version 6.7).
+
+```
+ssh example.com ssh-keygen -l -f /etc/ssh/ssh_host_ed25519_key.pub | cut -d ' ' -f2
+```
+
+Now you can adjust you config:
+
+```diff
+  - name: ssh key passphrase
+    uses: appleboy/ssh-action@master
+    with:
+      host: ${{ secrets.HOST }}
+      username: ${{ secrets.USERNAME }}
+      key: ${{ secrets.KEY }}
+      port: ${{ secrets.PORT }}
++     fingerprint: ${{ secrets.FINGERPRINT }}
+      script: |
+        whoami
+        ls -al
+```
+
 ## Contributing
 We would love for you to contribute to `appleboy/ssh-action`, pull requests are welcome!
 


### PR DESCRIPTION
This adds a new section to the README.md to explain how the host fingerprint validation can be set up. Closes #81.