### PR TITLE
Switch to appleboy/drone-ssh:1.6.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM appleboy/drone-ssh:1.6.3-linux-amd64
+FROM appleboy/drone-ssh:1.6.4-linux-amd64
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
While trying to handle the problem mentioned in the following issue I switched to the latest version of **drone-ssh** and it made it work. @appleboy, please consider updating the Dockerfile.
https://github.com/appleboy/ssh-action/issues/170