### PR TITLE
use fixed version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: executing remote ssh commands using password
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v0.1.5
       with:
         host: ${{ secrets.HOST }}
         username: ${{ secrets.USERNAME }}
@@ -190,7 +190,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: executing remote ssh commands using password
-  uses: appleboy/ssh-action@master
+  uses: appleboy/ssh-action@v0.1.5
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -203,7 +203,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: executing remote ssh commands using ssh key
-  uses: appleboy/ssh-action@master
+  uses: appleboy/ssh-action@v0.1.5
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -216,7 +216,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: multiple command
-  uses: appleboy/ssh-action@master
+  uses: appleboy/ssh-action@v0.1.5
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -233,7 +233,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@master
+    uses: appleboy/ssh-action@v0.1.5
     with:
 -     host: "foo.com"
 +     host: "foo.com,bar.com"
@@ -249,7 +249,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@master
+    uses: appleboy/ssh-action@v0.1.5
     with:
 -     host: "foo.com"
 +     host: "foo.com:1234,bar.com:5678"
@@ -264,7 +264,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@master
+    uses: appleboy/ssh-action@v0.1.5
     with:
       host: "foo.com,bar.com"
 +     sync: true
@@ -280,7 +280,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: pass environment
-    uses: appleboy/ssh-action@master
+    uses: appleboy/ssh-action@v0.1.5
 +   env:
 +     FOO: "BAR"
 +     BAR: "FOO"
@@ -305,7 +305,7 @@ _Inside `env` object, you need to pass every environment variable as a string, p
 
 ```diff
   - name: stop script if command error
-    uses: appleboy/ssh-action@master
+    uses: appleboy/ssh-action@v0.1.5
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -358,7 +358,7 @@ Host FooServer
 
 ```diff
   - name: ssh proxy command
-    uses: appleboy/ssh-action@master
+    uses: appleboy/ssh-action@v0.1.5
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -381,7 +381,7 @@ It is not uncommon for files to leak from backups or decommissioned hardware, an
 
 ```diff
   - name: ssh key passphrase
-    uses: appleboy/ssh-action@master
+    uses: appleboy/ssh-action@v0.1.5
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -407,7 +407,7 @@ Now you can adjust you config:
 
 ```diff
   - name: ssh key passphrase
-    uses: appleboy/ssh-action@master
+    uses: appleboy/ssh-action@v0.1.5
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
I suggest to use a fixed version in the documentation like @larrrssss suggests [here](https://github.com/appleboy/ssh-action/pull/198#issuecomment-1340561928) so that people don't get into troubles like today.

An alternative approach might be to use a branch named `stable` which is always set the the latest stable released version.