### PR TITLE
chore(security): update drone-ssh to v1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ghcr.io/appleboy/drone-ssh:1.7.0
+FROM ghcr.io/appleboy/drone-ssh:1.7.1
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+COPY entrypoint.sh /bin/entrypoint.sh
+
+ENTRYPOINT ["/bin/entrypoint.sh"]


### PR DESCRIPTION
- Update the base image in Dockerfile from `1.7.0` to `1.7.1`
- Change the location of `entrypoint.sh` from root to `/bin/` directory in Dockerfile
- Remove the explicit `chmod +x` command for `entrypoint.sh` in Dockerfile