### PR TITLE
ci: enhance GitHub Actions for IPv6 and flexibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,3 +282,32 @@ jobs:
           script: |
             whoami && echo 'hello world' && touch todo.txt
             sudo whoami
+
+  testing06:
+    name: testing ipv6
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: Set up WARP
+        uses: fscarmen/warp-on-actions@v1.1
+        with:
+          stack: dual
+
+      - name: testing ipv6 for command
+        run: |
+          curl -m 9 --ipv6 --verbose https://google.com
+          ping6 2402:1f00:8000:800::2628 -c 4
+
+      - name: testing ipv6
+        uses: ./
+        with:
+          host: 2402:1f00:8000:800::2628
+          username: ubuntu
+          password: ${{ secrets.OVH_PASSWORD }}
+          protocol: tcp6
+          port: 22
+          command_timeout: 30s
+          script: |
+            whoami

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,6 @@ jobs:
       - name: testing ipv6 for command
         run: |
           curl -m 9 --ipv6 --verbose https://google.com
-          ping6 2402:1f00:8000:800::2628 -c 4
 
       - name: testing ipv6
         uses: ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/appleboy/drone-ssh:1.7.3
+FROM ghcr.io/appleboy/drone-ssh:1.7.4
 
 COPY entrypoint.sh /bin/entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     description: "SSH username."
   password:
     description: "SSH password."
+  protocol:
+    description: 'The IP protocol to use. Valid values are "tcp". "tcp4" or "tcp6". Default to tcp.'
+    default: "tcp"
   sync:
     description: "Enable synchronous execution if multiple hosts are involved."
   use_insecure_cipher:
@@ -69,9 +72,54 @@ inputs:
     description: "pass all environment variable to shell script."
   request_pty:
     description: "Request a pseudo-terminal from the server."
+# runs:
+#   using: "docker"
+#   image: "Dockerfile"
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  using: "composite"
+  steps:
+    - name: Set GitHub Path
+      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+      shell: bash
+      env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+    - name: Run entrypoint.sh
+      run: entrypoint.sh
+      shell: bash
+      env:
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
+        INPUT_HOST: ${{ inputs.host }}
+        INPUT_PORT: ${{ inputs.port }}
+        INPUT_PROTOCOL: ${{ inputs.protocol }}
+        INPUT_USERNAME: ${{ inputs.username }}
+        INPUT_PASSWORD: ${{ inputs.password }}
+        INPUT_PASSPHRASE: ${{ inputs.passphrase }}
+        INPUT_KEY: ${{ inputs.key }}
+        INPUT_KEY_PATH: ${{ inputs.key_path }}
+        INPUT_FINGERPRINT: ${{ inputs.fingerprint }}
+        INPUT_PROXY_HOST: ${{ inputs.proxy_host }}
+        INPUT_PROXY_PORT: ${{ inputs.proxy_port }}
+        INPUT_PROXY_USERNAME: ${{ inputs.proxy_username }}
+        INPUT_PROXY_PASSWORD: ${{ inputs.proxy_password }}
+        INPUT_PROXY_PASSPHRASE: ${{ inputs.proxy_passphrase }}
+        INPUT_PROXY_KEY: ${{ inputs.proxy_key }}
+        INPUT_PROXY_KEY_PATH: ${{ inputs.proxy_key_path }}
+        INPUT_PROXY_FINGERPRINT: ${{ inputs.proxy_fingerprint }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+        INPUT_PROXY_TIMEOUT: ${{ inputs.proxy_timeout }}
+        INPUT_COMMAND_TIMEOUT: ${{ inputs.command_timeout }}
+        INPUT_SCRIPT: ${{ inputs.script }}
+        INPUT_SCRIPT_STOP: ${{ inputs.script_stop }}
+        INPUT_ENVS: ${{ inputs.envs }}
+        INPUT_ENVS_FORMAT: ${{ inputs.envs_format }}
+        INPUT_DEBUG: ${{ inputs.debug }}
+        INPUT_ALL_ENVS: ${{ inputs.allenvs }}
+        INPUT_REQUEST_PTY: ${{ inputs.request_pty }}
+        INPUT_USE_INSECURE_CIPHER: ${{ inputs.use_insecure_cipher }}
+        INPUT_CIPHER: ${{ inputs.cipher }}
+        INPUT_PROXY_USE_INSECURE_CIPHER: ${{ inputs.proxy_use_insecure_cipher }}
+        INPUT_PROXY_CIPHER: ${{ inputs.proxy_cipher }}
+        INPUT_SYNC: ${{ inputs.sync }}
 
 branding:
   icon: "terminal"

--- a/action.yml
+++ b/action.yml
@@ -72,9 +72,7 @@ inputs:
     description: "pass all environment variable to shell script."
   request_pty:
     description: "Request a pseudo-terminal from the server."
-# runs:
-#   using: "docker"
-#   image: "Dockerfile"
+
 runs:
   using: "composite"
   steps:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,66 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
+set -o pipefail
 
 export GITHUB="true"
 
-sh -c "/bin/drone-ssh $*"
+DRONE_SSH_RELEASE_URL="${DRONE_SSH_RELEASE_URL:-https://github.com/appleboy/drone-ssh/releases/download}"
+DRONE_SSH_VERSION="${DRONE_SSH_VERSION:-1.7.4}"
+
+function detect_client_info() {
+  if [ -n "${SSH_CLIENT_OS-}" ]; then
+    CLIENT_PLATFORM="${SSH_CLIENT_OS}"
+  else
+    local kernel
+    kernel="$(uname -s)"
+    case "${kernel}" in
+      Darwin)
+        CLIENT_PLATFORM="darwin"
+        ;;
+      Linux)
+        CLIENT_PLATFORM="linux"
+        ;;
+      Windows)
+        CLIENT_PLATFORM="windows"
+        ;;
+      *)
+        echo "Unknown, unsupported platform: ${kernel}." >&2
+        echo "Supported platforms: Linux, Darwin and Windows." >&2
+        echo "Bailing out." >&2
+        exit 2
+    esac
+  fi
+
+  if [ -n "${SSH_CLIENT_ARCH-}" ]; then
+    CLIENT_ARCH="${SSH_CLIENT_ARCH}"
+  else
+    # TODO: migrate the kube::util::host_platform function out of hack/lib and
+    # use it here.
+    local machine
+    machine="$(uname -m)"
+    case "${machine}" in
+      x86_64*|i?86_64*|amd64*)
+        CLIENT_ARCH="amd64"
+        ;;
+      aarch64*|arm64*)
+        CLIENT_ARCH="arm64"
+        ;;
+      *)
+        echo "Unknown, unsupported architecture (${machine})." >&2
+        echo "Supported architectures x86_64, i686, arm64." >&2
+        echo "Bailing out." >&2
+        exit 3
+        ;;
+    esac
+  fi
+}
+
+detect_client_info
+DOWNLOAD_URL_PREFIX="${DRONE_SSH_RELEASE_URL}/v${DRONE_SSH_VERSION}"
+CLIENT_BINARY="drone-ssh-${DRONE_SSH_VERSION}-${CLIENT_PLATFORM}-${CLIENT_ARCH}"
+echo "Will download ${CLIENT_BINARY} from ${DOWNLOAD_URL_PREFIX}"
+curl -fL --retry 3 --keepalive-time 2 "${DOWNLOAD_URL_PREFIX}/${CLIENT_BINARY}" -o ${GITHUB_ACTION_PATH}/drone-ssh
+chmod +x ${GITHUB_ACTION_PATH}drone-ssh
+sh -c "${GITHUB_ACTION_PATH}/drone-ssh $*"


### PR DESCRIPTION
- Add a new CI job for testing IPv6 in GitHub Actions workflow
- Update the Docker image version from `1.7.3` to `1.7.4`
- Add a new `protocol` input parameter to the GitHub action with a default value of `tcp`
- Change the GitHub action to use a composite run steps action instead of a Docker container
- Update the `entrypoint.sh` script to use `bash` instead of `sh`, set stricter error handling, and add a function to detect client platform and architecture
- Modify the `entrypoint.sh` script to download a specific version of `drone-ssh` based on the detected client info and execute it

fixed https://github.com/appleboy/ssh-action/issues/146
reference: https://github.com/actions/runner-images/issues/668