### PR TITLE
ci(action): remove script stop functionality from project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,22 +123,6 @@ jobs:
           port: 2222
           script: whoami
 
-      - name: stop script if command error
-        uses: ./
-        continue-on-error: true
-        with:
-          host: ${{ env.REMOTE_HOST }}
-          username: linuxserver.io
-          password: password
-          key: password
-          port: 2222
-          script_stop: true
-          sync: true
-          debug: true
-          script: |
-            mkdir abc/def
-            ls -al
-
   support-key-passphrase:
     runs-on: ubuntu-latest
     steps:
@@ -215,7 +199,6 @@ jobs:
           key: ${{ env.PRIVATE_KEY }}
           port: 2222
           passphrase: 1234
-          script_stop: true
           script: |
             ls \
               -lah
@@ -292,7 +275,6 @@ jobs:
           username: linuxserver.io
           key: ${{ env.PRIVATE_KEY }}
           passphrase: 1234
-          script_stop: true
           script: |
             whoami
 
@@ -488,7 +470,6 @@ jobs:
           username: linuxserver.io
           key: ${{ env.PRIVATE_KEY }}
           port: 2222
-          script_stop: true
           request_pty: true
           command_timeout: 30s
           script: |

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -123,22 +123,6 @@ jobs:
           port: 2222
           script: whoami
 
-      - name: stop script if command error
-        uses: appleboy/ssh-action@v1.2.0
-        continue-on-error: true
-        with:
-          host: ${{ env.REMOTE_HOST }}
-          username: linuxserver.io
-          password: password
-          key: password
-          port: 2222
-          script_stop: true
-          sync: true
-          debug: true
-          script: |
-            mkdir abc/def
-            ls -al
-
   support-key-passphrase:
     runs-on: ubuntu-latest
     steps:
@@ -215,7 +199,6 @@ jobs:
           key: ${{ env.PRIVATE_KEY }}
           port: 2222
           passphrase: 1234
-          script_stop: true
           script: |
             ls \
               -lah
@@ -292,7 +275,6 @@ jobs:
           username: linuxserver.io
           key: ${{ env.PRIVATE_KEY }}
           passphrase: 1234
-          script_stop: true
           script: |
             whoami
 
@@ -478,7 +460,6 @@ jobs:
           username: linuxserver.io
           key: ${{ env.PRIVATE_KEY }}
           port: 2222
-          script_stop: true
           request_pty: true
           command_timeout: 30s
           script: |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ See [action.yml](./action.yml) for more detailed information.
 | proxy_use_insecure_cipher | Include more ciphers with use_insecure_cipher for the proxy                              | false         |
 | script                    | Execute commands                                                                         |               |
 | script_file               | Execute commands from a file                                                             |               |
-| script_stop               | Stop script after first failure                                                          | false         |
 | envs                      | Pass environment variables to shell script                                               |               |
 | envs_format               | Flexible configuration of environment value transfer                                     |               |
 | debug                     | Enable debug mode                                                                        | false         |
@@ -303,37 +302,6 @@ The default value of `port` is `22`.
 ```
 
 _Inside `env` object, you need to pass every environment variable as a string, passing `Integer` data type or any other may output unexpected results._
-
-#### Stop script after first failure
-
-> ex: missing `abc` folder
-
-```diff
-  - name: stop script if command error
-    uses: appleboy/ssh-action@v1.2.0
-    with:
-      host: ${{ secrets.HOST }}
-      username: ${{ secrets.USERNAME }}
-      key: ${{ secrets.KEY }}
-      port: ${{ secrets.PORT }}
-+     script_stop: true
-      script: |
-        mkdir abc/def
-        ls -al
-```
-
-output:
-
-```sh
-======CMD======
-mkdir abc/def
-ls -al
-
-======END======
-2019/11/21 01:16:21 Process exited with status 1
-err: mkdir: cannot create directory ‘abc/def’: No such file or directory
-##[error]Docker run failed with exit code 1
-```
 
 #### How to connect remote server using `ProxyCommand`?
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -44,7 +44,6 @@
 | proxy_use_insecure_cipher | 使用不安全的密码算法                                  | false  |
 | script                    | 执行命令                                              |        |
 | script_file               | 从文件执行命令                                        |        |
-| script_stop               | 在第一次失败后停止脚本                                | false  |
 | envs                      | 传递环境变量到 shell 脚本                             |        |
 | envs_format               | 环境变量传递的灵活配置                                |        |
 | debug                     | 启用调试模式                                          | false  |
@@ -284,37 +283,6 @@ ssh-keygen -t ed25519 -a 200 -C ”your_email@example.com“
 ```
 
 _在 `env` 对象中，您需要将每个环境变量作为字符串传递，传递 `Integer` 数据类型或任何其他类型可能会产生意外结果。_
-
-#### 在第一次失败后停止脚本
-
-> ex: missing `abc` folder
-
-```diff
-  - name: stop script if command error
-    uses: appleboy/ssh-action@v1.2.0
-    with:
-      host: ${{ secrets.HOST }}
-      username: ${{ secrets.USERNAME }}
-      key: ${{ secrets.KEY }}
-      port: ${{ secrets.PORT }}
-+     script_stop: true
-      script: |
-        mkdir abc/def
-        ls -al
-```
-
-画面输出：
-
-```sh
-======CMD======
-mkdir abc/def
-ls -al
-
-======END======
-2019/11/21 01:16:21 Process exited with status 1
-err: mkdir: cannot create directory ‘abc/def’: No such file or directory
-##[error]Docker run failed with exit code 1
-```
 
 #### 如何使用 `ProxyCommand` 连接远程服务器？
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -44,7 +44,6 @@
 | proxy_use_insecure_cipher | 包含更多不安全的加密算法                              | false  |
 | script                    | 執行命令                                              |        |
 | script_file               | 從文件中執行命令                                      |        |
-| script_stop               | 在第一次失敗後停止腳本                                | false  |
 | envs                      | 將環境變數傳遞給 shell 腳本                           |        |
 | envs_format               | 環境值傳遞的靈活配置                                  |        |
 | debug                     | 啟用調試模式                                          | false  |
@@ -284,37 +283,6 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 ```
 
 _在 `env` 對象中，您需要將每個環境變量作為字符串傳遞，傳遞 `Integer` 數據類型或任何其他類型可能會產生意外結果。_
-
-#### 在第一次失敗後停止腳本
-
-> ex: missing `abc` folder
-
-```diff
-  - name: stop script if command error
-    uses: appleboy/ssh-action@v1.2.0
-    with:
-      host: ${{ secrets.HOST }}
-      username: ${{ secrets.USERNAME }}
-      key: ${{ secrets.KEY }}
-      port: ${{ secrets.PORT }}
-+     script_stop: true
-      script: |
-        mkdir abc/def
-        ls -al
-```
-
-畫面輸出:
-
-```sh
-======CMD======
-mkdir abc/def
-ls -al
-
-======END======
-2019/11/21 01:16:21 Process exited with status 1
-err: mkdir: cannot create directory ‘abc/def’: No such file or directory
-##[error]Docker run failed with exit code 1
-```
 
 #### 如何使用 `ProxyCommand` 連接遠程服務器？
 

--- a/action.yml
+++ b/action.yml
@@ -65,8 +65,6 @@ inputs:
     description: "Commands to be executed."
   script_path:
     description: "Path to the file containing commands to be executed."
-  script_stop:
-    description: "Stop the script after the first failure."
   envs:
     description: "Environment variables to be passed to the shell script."
   envs_format:
@@ -113,7 +111,6 @@ runs:
         INPUT_COMMAND_TIMEOUT: ${{ inputs.command_timeout }}
         INPUT_SCRIPT: ${{ inputs.script }}
         INPUT_SCRIPT_FILE: ${{ inputs.script_path }}
-        INPUT_SCRIPT_STOP: ${{ inputs.script_stop }}
         INPUT_ENVS: ${{ inputs.envs }}
         INPUT_ENVS_FORMAT: ${{ inputs.envs_format }}
         INPUT_DEBUG: ${{ inputs.debug }}


### PR DESCRIPTION
- Remove the `stop script if command error` step from GitHub workflows
- Remove the `script_stop` option from the README and its translations
- Remove the `script_stop` input from `action.yml`

fix #335
fix #130

