### PR TITLE
ci: add SSH testing job to GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -622,8 +622,8 @@ jobs:
           echo "======================================"
           sleep 2
 
-      - id: stdout
-        name: ssh command with stdout
+      - id: stdout01
+        name: ssh command with stdout 01
         uses: ./
         with:
           host: ${{ env.REMOTE_HOST }}
@@ -641,13 +641,43 @@ jobs:
               echo "False"
             fi
 
-      - name: check stdout
+      - name: check stdout 01
         run: |
-          echo "stdout: ${{ steps.stdout.outputs.stdout }}"
-          if echo "${{ steps.stdout.outputs.stdout }}" | grep -q "True"; then
+          echo "stdout: ${{ steps.stdout01.outputs.stdout }}"
+          if echo "${{ steps.stdout01.outputs.stdout }}" | grep -q "True"; then
             echo "Output contains 'True'"
             exit 1
           fi
-          if echo "${{ steps.stdout.outputs.stdout }}" | grep -q "False"; then
+          if echo "${{ steps.stdout01.outputs.stdout }}" | grep -q "False"; then
             echo "Output contains 'False'"
+          fi
+
+      - id: stdout02
+        name: ssh command with stdout 01
+        uses: ./
+        with:
+          host: ${{ env.REMOTE_HOST }}
+          username: linuxserver.io
+          password: password
+          port: 2222
+          capture_stdout: true
+          script: |
+            #!/usr/bin/env bash
+            set -e
+            echo "TMP TESTING IF"
+            if [[ "1" == "1" ]]; then
+              echo "True"
+            else
+              echo "False"
+            fi
+
+      - name: check stdout 02
+        run: |
+          echo "stdout: ${{ steps.stdout02.outputs.stdout }}"
+          if echo "${{ steps.stdout02.outputs.stdout }}" | grep -q "False"; then
+            echo "Output contains 'False'"
+            exit 1
+          fi
+          if echo "${{ steps.stdout02.outputs.stdout }}" | grep -q "True"; then
+            echo "Output contains 'True'"
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -594,3 +594,53 @@ jobs:
       - name: check stdout
         run: |
           echo "stdout: ${{ steps.stdout.outputs.stdout }}"
+
+  testing-script-stop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: create new ssh server
+        run: |
+          docker run -d \
+          --name=openssh-server \
+          --hostname=openssh-server \
+          -p 2222:2222 \
+          -e SUDO_ACCESS=false \
+          -e PASSWORD_ACCESS=true  \
+          -e USER_PASSWORD=password  \
+          -e USER_NAME=linuxserver.io \
+          --restart unless-stopped \
+          lscr.io/linuxserver/openssh-server:latest
+          docker exec openssh-server sh -c "hostname -i" > ip.txt
+          echo "REMOTE_HOST<<EOF" >> $GITHUB_ENV
+          cat ip.txt >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "======= container ip address ========="
+          cat ip.txt
+          echo "======================================"
+          sleep 2
+
+      - id: stdout
+        name: ssh command with stdout
+        uses: ./
+        with:
+          host: ${{ env.REMOTE_HOST }}
+          username: linuxserver.io
+          password: password
+          port: 2222
+          capture_stdout: true
+          script: |
+            #!/usr/bin/env bash
+            set -e
+            echo "TMP TESTING IF"
+            if [[ "2" == "1" ]]; then
+              echo "True"
+            else
+              echo "False"
+            fi
+
+      - name: check stdout
+        run: |
+          echo "stdout: ${{ steps.stdout.outputs.stdout }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -644,3 +644,10 @@ jobs:
       - name: check stdout
         run: |
           echo "stdout: ${{ steps.stdout.outputs.stdout }}"
+          if echo "${{ steps.stdout.outputs.stdout }}" | grep -q "True"; then
+            echo "Output contains 'True'"
+            exit 1
+          fi
+          if echo "${{ steps.stdout.outputs.stdout }}" | grep -q "False"; then
+            echo "Output contains 'False'"
+          fi


### PR DESCRIPTION
- Add a new job `testing-script-stop` to the GitHub Actions workflow
- Set up an SSH server using a Docker container within the new job
- Capture the container's IP address and store it in the GitHub environment
- Add a step to run an SSH command with stdout capture
- Include a script to test conditional logic within the SSH command
- Add a step to check and print the captured stdout from the SSH command

fix https://github.com/appleboy/ssh-action/issues/335#issuecomment-2372414496