### PR TITLE
docs: standardize `script_file` naming to `script_path` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [action.yml](./action.yml) for more detailed information.
 | proxy_cipher              | Allowed cipher algorithms for the proxy                                                  |               |
 | proxy_use_insecure_cipher | Include more ciphers with use_insecure_cipher for the proxy                              | false         |
 | script                    | Execute commands                                                                         |               |
-| script_file               | Execute commands from a file                                                             |               |
+| script_path               | Execute commands from a file                                                             |               |
 | envs                      | Pass environment variables to shell script                                               |               |
 | envs_format               | Flexible configuration of environment value transfer                                     |               |
 | debug                     | Enable debug mode                                                                        | false         |

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -43,7 +43,7 @@
 | proxy_cipher              | 代理允许的密码算法                                    |        |
 | proxy_use_insecure_cipher | 使用不安全的密码算法                                  | false  |
 | script                    | 执行命令                                              |        |
-| script_file               | 从文件执行命令                                        |        |
+| script_path               | 从文件执行命令                                        |        |
 | envs                      | 传递环境变量到 shell 脚本                             |        |
 | envs_format               | 环境变量传递的灵活配置                                |        |
 | debug                     | 启用调试模式                                          | false  |

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -43,7 +43,7 @@
 | proxy_cipher              | 代理允許的加密算法                                    |        |
 | proxy_use_insecure_cipher | 包含更多不安全的加密算法                              | false  |
 | script                    | 執行命令                                              |        |
-| script_file               | 從文件中執行命令                                      |        |
+| script_path               | 從文件中執行命令                                      |        |
 | envs                      | 將環境變數傳遞給 shell 腳本                           |        |
 | envs_format               | 環境值傳遞的靈活配置                                  |        |
 | debug                     | 啟用調試模式                                          | false  |


### PR DESCRIPTION
- Rename `script_file` to `script_path` in README.md
- Rename `script_file` to `script_path` in README.zh-cn.md
- Rename `script_file` to `script_path` in README.zh-tw.md

fix #358 