### PR TITLE
docs(readme): `set -e` for `script_stop` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ See [action.yml](./action.yml) for more detailed information.
 | allenvs                   | Pass the environment variables with prefix value of `GITHUB_` and `INPUT_` to the script | false         |
 | request_pty               | Request a pseudo-terminal from the server                                                | false         |
 
+**Note:** Users can add `set -e` in their shell script to achieve similar functionality to the removed `script_stop` option.
+
 ## Usage
 
 Executing remote SSH commands.

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -50,6 +50,8 @@
 | allenvs                   | 将带有 `GITHUB_` 和 `INPUT_` 前缀的环境变量传递给脚本 | false  |
 | request_pty               | 请求伪终端                                            | false  |
 
+**注意：** 用户可以在他们的 shell 脚本中添加 `set -e` 以实现类似于已删除的 `script_stop` 选项的功能。
+
 ## 使用方法
 
 执行远程 SSH 命令

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -50,6 +50,8 @@
 | allenvs                   | 將帶有 `GITHUB_` 和 `INPUT_` 前綴的環境變數傳遞給腳本 | false  |
 | request_pty               | 從伺服器請求偽終端                                    | false  |
 
+**注意：** 用戶可以在他們的 shell 腳本中添加 `set -e` 以實現類似於已刪除的 `script_stop` 選項的功能。
+
 ## 用法
 
 執行遠端 SSH 命令


### PR DESCRIPTION
Fixes #367

Add a note in the "Input variables" section of `README.md` to mention that users can add `set -e` in their shell script to achieve similar functionality to the removed `script_stop` option.

Add a note in the "输入变量" section of `README.zh-cn.md` to mention that users can add `set -e` in their shell script to achieve similar functionality to the removed `script_stop` option.

Add a note in the "輸入變數" section of `README.zh-tw.md` to mention that users can add `set -e` in their shell script to achieve similar functionality to the removed `script_stop` option.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/appleboy/ssh-action/pull/368?shareId=f3d9272e-e417-4aee-98b6-c34b127ec857).