### PR TITLE
docs: update SSH action version to v1 in all README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: executing remote ssh commands using password
-        uses: appleboy/ssh-action@v1.2.2
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.HOST }}
           username: linuxserver.io
@@ -183,7 +183,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: executing remote ssh commands using password
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -196,7 +196,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: executing remote ssh commands using ssh key
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -209,7 +209,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: multiple command
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -226,7 +226,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: file commands
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -239,7 +239,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
 -     host: "foo.com"
 +     host: "foo.com,bar.com"
@@ -257,7 +257,7 @@ The default value of `port` is `22`.
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
 -     host: "foo.com"
 +     host: "foo.com:1234,bar.com:5678"
@@ -272,7 +272,7 @@ The default value of `port` is `22`.
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: "foo.com,bar.com"
 +     sync: true
@@ -288,7 +288,7 @@ The default value of `port` is `22`.
 
 ```diff
   - name: pass environment
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
 +   env:
 +     FOO: "BAR"
 +     BAR: "FOO"
@@ -335,7 +335,7 @@ Host FooServer
 
 ```diff
   - name: ssh proxy command
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -358,7 +358,7 @@ It is not uncommon for files to leak from backups or decommissioned hardware, an
 
 ```diff
   - name: ssh key passphrase
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -384,7 +384,7 @@ Now you can adjust you config:
 
 ```diff
   - name: ssh key passphrase
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: executing remote ssh commands using password
-        uses: appleboy/ssh-action@v1.2.2
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.HOST }}
           username: linuxserver.io
@@ -183,7 +183,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: executing remote ssh commands using password
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -196,7 +196,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: executing remote ssh commands using ssh key
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -209,7 +209,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: multiple command
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -226,7 +226,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: file commands
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -239,7 +239,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
 -     host: "foo.com"
 +     host: "foo.com,bar.com"
@@ -257,7 +257,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
 -     host: "foo.com"
 +     host: "foo.com:1234,bar.com:5678"
@@ -272,7 +272,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: "foo.com,bar.com"
 +     sync: true
@@ -288,7 +288,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: pass environment
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
 +   env:
 +     FOO: "BAR"
 +     BAR: "FOO"
@@ -335,7 +335,7 @@ Host FooServer
 
 ```diff
   - name: ssh proxy command
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -356,7 +356,7 @@ Host FooServer
 
 ```diff
   - name: ssh key passphrase
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -382,7 +382,7 @@ ssh example.com ssh-keygen -l -f /etc/ssh/ssh_host_ed25519_key.pub | cut -d ' ' 
 
 ```diff
   - name: ssh key passphrase
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: executing remote ssh commands using password
-        uses: appleboy/ssh-action@v1.2.2
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.HOST }}
           username: linuxserver.io
@@ -181,7 +181,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: executing remote ssh commands using password
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -194,7 +194,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: executing remote ssh commands using ssh key
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -207,7 +207,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: multiple command
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -224,7 +224,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```yaml
 - name: file commands
-  uses: appleboy/ssh-action@v1.2.2
+  uses: appleboy/ssh-action@v1
   with:
     host: ${{ secrets.HOST }}
     username: ${{ secrets.USERNAME }}
@@ -237,7 +237,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
 -     host: "foo.com"
 +     host: "foo.com,bar.com"
@@ -253,7 +253,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
 -     host: "foo.com"
 +     host: "foo.com:1234,bar.com:5678"
@@ -268,7 +268,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: multiple host
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: "foo.com,bar.com"
 +     sync: true
@@ -284,7 +284,7 @@ ssh-keygen -t ed25519 -a 200 -C "your_email@example.com"
 
 ```diff
   - name: pass environment
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
 +   env:
 +     FOO: "BAR"
 +     BAR: "FOO"
@@ -331,7 +331,7 @@ Host FooServer
 
 ```diff
   - name: ssh proxy command
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -352,7 +352,7 @@ Host FooServer
 
 ```diff
   - name: ssh key passphrase
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}
@@ -378,7 +378,7 @@ ssh example.com ssh-keygen -l -f /etc/ssh/ssh_host_ed25519_key.pub | cut -d ' ' 
 
 ```diff
   - name: ssh key passphrase
-    uses: appleboy/ssh-action@v1.2.2
+    uses: appleboy/ssh-action@v1
     with:
       host: ${{ secrets.HOST }}
       username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
- Update 'appleboy/ssh-action' version from 'v1.2.2' to 'v1' in various locations in the README.md file
- Update 'appleboy/ssh-action' version from 'v1.2.2' to 'v1' in various locations in README.zh-cn.md
- Update 'appleboy/ssh-action' version from 'v1.2.2' to 'v1' in various locations in README.zh-tw.md

fix #201 