### PR TITLE
docs: document and configure drone-ssh version usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Refer to [action.yml](./action.yml) for more detailed information.
 | allenvs                   | Pass the environment variables with prefix value of `GITHUB_` and `INPUT_` to the script | false         |
 | request_pty               | Request a pseudo-terminal from the server                                                | false         |
 | curl_insecure             | Allow curl to connect to SSL sites without certificates                                  | false         |
+| version                   | drone-ssh binary version. If not specified, the latest version will be used.             |               |
 
 **Note:** Users can add `set -e` in their shell script to achieve similar functionality to the removed `script_stop` option.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -50,6 +50,7 @@
 | allenvs                   | 将带有 `GITHUB_` 和 `INPUT_` 前缀的环境变量传递给脚本 | false  |
 | request_pty               | 请求伪终端                                            | false  |
 | curl_insecure             | 在 curl 中使用不安全的证书验证                        | false  |
+| version                   | drone-ssh 版本号。若未指定，将使用最新版本。          |        |
 
 **注意：** 用户可以在他们的 shell 脚本中添加 `set -e` 以实现类似于已删除的 `script_stop` 选项的功能。
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -50,6 +50,7 @@
 | allenvs                   | 將帶有 `GITHUB_` 和 `INPUT_` 前綴的環境變數傳遞給腳本 | false  |
 | request_pty               | 從伺服器請求偽終端                                    | false  |
 | curl_insecure             | 在 curl 命令中使用不安全的 SSL 證書驗證               | false  |
+| version                   | drone-ssh 版本號。若未指定，將使用最新版本。          |        |
 
 **注意：** 用戶可以在他們的 shell 腳本中添加 `set -e` 以實現類似於已刪除的 `script_stop` 選項的功能。
 

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,9 @@ inputs:
   capture_stdout:
     description: "When true, captures and returns standard output from the commands as action output."
     default: "false"
+  version:
+    description: |
+      The version of drone-ssh to use.
 
 outputs:
   stdout:
@@ -135,6 +138,7 @@ runs:
         INPUT_SYNC: ${{ inputs.sync }}
         INPUT_CAPTURE_STDOUT: ${{ inputs.capture_stdout }}
         INPUT_CURL_INSECURE: ${{ inputs.curl_insecure }}
+        DRONE_SSH_VERSION: ${{ inputs.version }}
 
 branding:
   icon: "terminal"


### PR DESCRIPTION
- Add `version` entry to README.md specifying drone-ssh binary version usage
- Add `version` entry to README.zh-cn.md specifying drone-ssh version usage in Chinese
- Add `version` entry to README.zh-tw.md specifying drone-ssh version usage in Traditional Chinese
- Add `version` input to action.yml with description for drone-ssh version
- Set DRONE_SSH_VERSION environment variable in action.yml to use specified version input