### PR TITLE
docs(readme): better wording for script_path property

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ These parameters control the commands executed on the remote host and related be
 | Parameter       | Description                                                                       | Default |
 | --------------- | --------------------------------------------------------------------------------- | ------- |
 | script          | Commands to execute remotely                                                      |         |
-| script_path     | Path to a file containing commands to execute                                     |         |
+| script_path     | Path to a file in the repository containing commands to execute remotely          |         |
 | envs            | Environment variables to pass to the shell script                                 |         |
 | envs_format     | Flexible configuration for environment variable transfer                          |         |
 | allenvs         | Pass all environment variables with `GITHUB_` and `INPUT_` prefixes to the script | false   |


### PR DESCRIPTION
Better wording for `script_path` property.

I also misunderstood this to be a script on the remote that will be called. As pointed out in this [comment here](https://github.com/appleboy/ssh-action/issues/384#issuecomment-2838163636) it refers to a path of a script in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the description of the `script_path` parameter in the SSH command settings to specify that the file should be located within the repository and that its commands are executed remotely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->