### PR TITLE
fix: prevent stdout duplication when capture_stdout is enabled

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,7 @@ echo "======================================="
 if [[ "${INPUT_CAPTURE_STDOUT}" == 'true' ]]; then
   {
     echo 'stdout<<EOF'
-    "${TARGET}" "$@" | tee -a "${GITHUB_OUTPUT}"
+    "${TARGET}" "$@" | tee /dev/stderr
     echo 'EOF'
   } >>"${GITHUB_OUTPUT}"
 else


### PR DESCRIPTION
## Summary

Fix output duplication bug when `capture_stdout: true` is enabled.

Fixes #397

## Problem

The bug was introduced in PR #374 (commit b6690ee) during a refactoring. The original implementation was correct:

```bash
# Original - correct
echo 'stdout<<EOF' >>$GITHUB_OUTPUT
sh -c "${TARGET} $*" | tee -a $GITHUB_OUTPUT
echo 'EOF' >>$GITHUB_OUTPUT
```

The refactoring wrapped everything in a subshell but kept `tee -a`:

```bash
# After refactoring - buggy
if [[ "${INPUT_CAPTURE_STDOUT}" == 'true' ]]; then
  {
    echo 'stdout<<EOF'
    "${TARGET}" "$@" | tee -a "${GITHUB_OUTPUT}"  # <-- 1st write
    echo 'EOF'
  } >>"${GITHUB_OUTPUT}"  # <-- 2nd write (subshell redirect)
```

This causes command output to be written **twice** to `GITHUB_OUTPUT`:
1. Via `tee -a "${GITHUB_OUTPUT}"` directly
2. Via the subshell `{ ... } >>"${GITHUB_OUTPUT}"` redirect

## Solution

Change `tee -a "${GITHUB_OUTPUT}"` to `tee /dev/stderr`:

- Real-time output is still visible in the Actions log (via stderr)
- Output is only written once to `GITHUB_OUTPUT` (via the subshell redirect)

## Testing

Tested in production CI/CD pipelines deploying to multiple servers. Before the fix, all captured output lines appeared duplicated. After the fix, output appears correctly once.