### PR TITLE
fix: Upgrade drone-ssh from 1.8.2 to 1.8.3

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ export GITHUB="true"
 
 GITHUB_ACTION_PATH="${GITHUB_ACTION_PATH%/}"
 DRONE_SSH_RELEASE_URL="${DRONE_SSH_RELEASE_URL:-https://github.com/appleboy/drone-ssh/releases/download}"
-DRONE_SSH_VERSION="${DRONE_SSH_VERSION:-1.8.2}"
+DRONE_SSH_VERSION="${DRONE_SSH_VERSION:-1.8.3}"
 
 # Error codes
 readonly ERR_UNKNOWN_PLATFORM=2


### PR DESCRIPTION
The bundled drone-ssh v1.8.2 was causing deployment failures with "Unexpected input(s) 'script_stop'" warnings and process exit code 128 during CI/CD runs. Upgrading to v1.8.3 resolves input validation issues and improves SSH session stability.

Deployment was failing at the git fetch step with:
  "remote: Repository not found.
   fatal: Authentication failed for 'https://github.com/...'"
  Process exited with status 128

Updated DRONE_SSH_VERSION default from 1.8.2 to 1.8.3 in entrypoint.sh.