### PR TITLE
fix: close captured output before returning failures

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,8 +72,17 @@ fi
 echo "======================================="
 if [[ "${INPUT_CAPTURE_STDOUT}" == 'true' ]]; then
   echo 'stdout<<EOF' >> "${GITHUB_OUTPUT}"
-  "${TARGET}" "$@" | tee -a "${GITHUB_OUTPUT}"
+  if "${TARGET}" "$@" | tee -a "${GITHUB_OUTPUT}"; then
+    capture_status=0
+  else
+    capture_status=$?
+  fi
+  output_last_byte_newline_count="$(tail -c 1 "${GITHUB_OUTPUT}" | wc -l)"
+  if [[ "${output_last_byte_newline_count}" -eq 0 ]]; then
+    echo >> "${GITHUB_OUTPUT}"
+  fi
   echo 'EOF' >> "${GITHUB_OUTPUT}"
+  exit "${capture_status}"
 else
   "${TARGET}" "$@"
 fi


### PR DESCRIPTION
## Summary

With `capture_stdout: true`, a nonzero `drone-ssh | tee` pipeline exits under `set -euo pipefail` before the closing `GITHUB_OUTPUT` delimiter is written.
This change records the pipeline status, completes the output record, and returns that status afterward.

## Evidence

- [`entrypoint.sh` on the current base](https://github.com/appleboy/ssh-action/blob/b838bc2f27cd449b957159452d432aff91697637/entrypoint.sh#L73-L76) opens the multiline value and executes the pipeline before writing its closing delimiter.
- [Issue #375](https://github.com/appleboy/ssh-action/issues/375) reports `Matching delimiter not found 'EOF'` and unavailable captured output after a nonzero remote command.
- A controlled executable that printed `payload` without a final newline and exited 17 reproduced exit 17 with the unterminated record `stdout<<EOF\npayload`.

## Changes

- Run the pipeline as an `if` condition so strict mode does not skip output-record cleanup.
- Preserve the pipeline's `pipefail` status and return it only after the closing delimiter is written.
- Add a separator only when stdout lacks a final newline, preserving successful newline-terminated and empty values.

## Risks and boundaries

- The delimiter remains the existing static `EOF`; delimiter collision is intentionally outside this pull request.
- Remote stderr ownership, output buffering, and command failure semantics remain unchanged.
- Output-file read or write failures still take precedence over the saved command status.

## Verification

- `bash -n entrypoint.sh && shellcheck entrypoint.sh && git diff --check` — passed.
- Controlled executable writes `payload` without a final newline and exits 17 — the entrypoint exits 17 and writes one complete `stdout` record.
- Controlled executable writes newline-terminated or empty stdout and exits 0 — the existing parsed value shape is preserved.
- Controlled executable writes stdout ending in NUL and exits 17 — the NUL is preserved and the output record remains complete.

I checked the relevant issues, comments, pull requests, discussions, and releases; this pull request is not a duplicate.

### Disclosure

Investigated thoroughly with GPT-5.6 Codex (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.