### PR TITLE
fix: map action inputs to drone-ssh environment names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,7 @@ runs:
         INPUT_FINGERPRINT: ${{ inputs.fingerprint }}
         INPUT_PROXY_HOST: ${{ inputs.proxy_host }}
         INPUT_PROXY_PORT: ${{ inputs.proxy_port }}
+        INPUT_PROXY_PROTOCOL: ${{ inputs.proxy_protocol }}
         INPUT_PROXY_USERNAME: ${{ inputs.proxy_username }}
         INPUT_PROXY_PASSWORD: ${{ inputs.proxy_password }}
         INPUT_PROXY_PASSPHRASE: ${{ inputs.proxy_passphrase }}
@@ -129,12 +130,12 @@ runs:
         INPUT_ENVS: ${{ inputs.envs }}
         INPUT_ENVS_FORMAT: ${{ inputs.envs_format }}
         INPUT_DEBUG: ${{ inputs.debug }}
-        INPUT_ALL_ENVS: ${{ inputs.allenvs }}
+        INPUT_ALLENVS: ${{ inputs.allenvs }}
         INPUT_REQUEST_PTY: ${{ inputs.request_pty }}
         INPUT_USE_INSECURE_CIPHER: ${{ inputs.use_insecure_cipher }}
-        INPUT_CIPHER: ${{ inputs.cipher }}
+        INPUT_CIPHERS: ${{ inputs.cipher }}
         INPUT_PROXY_USE_INSECURE_CIPHER: ${{ inputs.proxy_use_insecure_cipher }}
-        INPUT_PROXY_CIPHER: ${{ inputs.proxy_cipher }}
+        INPUT_PROXY_CIPHERS: ${{ inputs.proxy_cipher }}
         INPUT_SYNC: ${{ inputs.sync }}
         INPUT_CAPTURE_STDOUT: ${{ inputs.capture_stdout }}
         INPUT_CURL_INSECURE: ${{ inputs.curl_insecure }}


### PR DESCRIPTION
## Summary

The composite adapter exports three public inputs under environment names that pinned `drone-ssh v1.8.2` does not consume and omits `proxy_protocol` entirely.
This change maps the four existing public inputs to the binary's recognized names without changing the action interface.

## Evidence

- [`action.yml` on the current base](https://github.com/appleboy/ssh-action/blob/b838bc2f27cd449b957159452d432aff91697637/action.yml#L105-L141) exports `INPUT_ALL_ENVS`, `INPUT_CIPHER`, and `INPUT_PROXY_CIPHER` and has no `INPUT_PROXY_PROTOCOL`.
- [`drone-ssh v1.8.2`](https://github.com/appleboy/drone-ssh/blob/9d94a36c84c95a692c27313a6726437ed344ae2a/main.go#L102-L106) consumes `INPUT_CIPHERS`.
- The same pinned source consumes [`INPUT_PROXY_PROTOCOL`](https://github.com/appleboy/drone-ssh/blob/9d94a36c84c95a692c27313a6726437ed344ae2a/main.go#L169-L177), [`INPUT_PROXY_CIPHERS`](https://github.com/appleboy/drone-ssh/blob/9d94a36c84c95a692c27313a6726437ed344ae2a/main.go#L233-L237), and [`INPUT_ALLENVS`](https://github.com/appleboy/drone-ssh/blob/9d94a36c84c95a692c27313a6726437ed344ae2a/main.go#L273-L277).
- [Pull request #303](https://github.com/appleboy/ssh-action/pull/303) introduced the composite mapping layer; no active issue or pull request currently fixes these names.

## Changes

- Map `allenvs` to `INPUT_ALLENVS`.
- Map `cipher` and `proxy_cipher` to `INPUT_CIPHERS` and `INPUT_PROXY_CIPHERS`.
- Map `proxy_protocol` to `INPUT_PROXY_PROTOCOL`.
- Preserve every public input name, value, default, and binary-owned validation path.

## Risks and boundaries

- The mappings are proven against the action's default `drone-ssh v1.8.2`; explicit custom version overrides remain outside this compatibility claim.
- No compatibility aliases, action-side validation, documentation changes, or generated mapping layer are added.
- Existing `envs` forwarding remains unchanged.

## Verification

- `yq v4.53.3` parsed `action.yml` and confirmed all four public declarations and exact recognized mappings.
- Assertions confirmed that `INPUT_ALL_ENVS`, `INPUT_CIPHER`, and `INPUT_PROXY_CIPHER` are no longer injected.
- `git diff --check` — passed.

I checked the relevant issues, comments, pull requests, discussions, releases, and both repositories' naming history; this pull request is not a duplicate.

### Disclosure

Investigated thoroughly with GPT-5.6 Codex (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.