### PR TITLE
fix: randomize the captured output delimiter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,9 +71,10 @@ if ! "${TARGET}" --version; then
 fi
 echo "======================================="
 if [[ "${INPUT_CAPTURE_STDOUT}" == 'true' ]]; then
-  echo 'stdout<<EOF' >> "${GITHUB_OUTPUT}"
+  OUTPUT_DELIMITER="EOF_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}"
+  echo "stdout<<${OUTPUT_DELIMITER}" >> "${GITHUB_OUTPUT}"
   "${TARGET}" "$@" | tee -a "${GITHUB_OUTPUT}"
-  echo 'EOF' >> "${GITHUB_OUTPUT}"
+  echo "${OUTPUT_DELIMITER}" >> "${GITHUB_OUTPUT}"
 else
   "${TARGET}" "$@"
 fi


### PR DESCRIPTION
## Summary

Captured stdout currently uses the fixed multiline delimiter `EOF`, although a remote command may legitimately emit `EOF` on a line by itself.
This change creates one randomized Bash-only delimiter per capture and uses it for both framing lines while retaining the streaming `tee` path.

## Evidence

- [`entrypoint.sh` on the current base](https://github.com/appleboy/ssh-action/blob/b838bc2f27cd449b957159452d432aff91697637/entrypoint.sh#L73-L76) frames every captured value with the literal line `EOF`.
- [GitHub's multiline-string contract](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings) requires that the delimiter not occur on a line by itself within the value.
- [The runner parser](https://github.com/actions/runner/blob/99e01149303b194e08778cdc9c03fa2703d03fb2/src/Runner.Worker/FileCommandManager.cs) closes a multiline value when a line equals its delimiter.
- A controlled capture of `vor\nEOF\nnach\n` produced static framing in which the first `EOF` closes the value before `nach`.

## Changes

- Generate one delimiter from eight underscore-separated Bash `$RANDOM` components for each capture invocation.
- Use the same quoted delimiter in the opening and closing `GITHUB_OUTPUT` lines.
- Keep the `drone-ssh | tee` pipeline, live logs, byte ordering, and public `stdout` output unchanged.

## Risks and boundaries

- `$RANDOM` is seedable pseudo-randomness, not cryptographic entropy; this removes the deterministic collision but not every theoretical or adversarial collision.
- GitHub warns that delimiter framing cannot safely represent completely arbitrary content without buffering; this pull request intentionally preserves streaming.
- Nonzero-pipeline cleanup, output without a final newline, and stderr ownership remain unchanged and outside this correction.

## Verification

- `bash -n entrypoint.sh && shellcheck entrypoint.sh && git diff --check` — passed.
- Controlled capture writes `vor`, `EOF`, and `nach` — one randomized framing pair encloses all three lines in order.
- Controlled executable exits 17 — the unchanged `pipefail` pipeline still returns 17.

I checked the relevant issues, comments, pull requests, discussions, releases, and capture history; this pull request is not a duplicate.

### Disclosure

Investigated thoroughly with GPT-5.6 Codex (high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.